### PR TITLE
Fix for navigation icon not being visible on mobile

### DIFF
--- a/stylesheet.less
+++ b/stylesheet.less
@@ -101,6 +101,12 @@ body.edit .widget.navigation, body.edit .widget.extendednavigation {
    EXTENDED NAVIGATION
    =============================== */
 
+[data-widget-type="extendednavigation"] {
+    @media @tablet {
+        min-height: 30px;
+    }
+}
+
 .widget.extendednavigation {
     position: relative;
     margin: 15px -20px 20px;


### PR DESCRIPTION
Relevant when the logo and or company name is hidden